### PR TITLE
Feature/compiler

### DIFF
--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -1,7 +1,8 @@
 /* eslint-disable prefer-object-spread, prefer-spread */
 import Complex from '../complex';
 import { E, I, PI } from '../constants';
-import { BinaryExpression, Expression, UnaryExpression, parse } from '../parser';
+import { BinaryExpression, Expression, UnaryExpression } from '../expressions';
+import parse from '../parser';
 import { acos, acosh, add, asin, asinh, atan, atanh, cbrt, conj, cos, cosh, div, exp, from, log, mod, mul, pow, proj, sin, sinh, sqrt, sub, tan, tanh, trunc } from '../static';
 
 export type Value = Complex | ((...args: Complex[]) => Complex);
@@ -37,41 +38,6 @@ export const bindings: Bindings = {
 
 const unexpectedExpressionType = (type: never) => new TypeError(`Unexpected expression type ${type}`);
 
-const transform = (expression: Expression): Expression<Complex> => {
-  const { type } = expression;
-
-  switch (type) {
-    case 'BinaryExpression':
-      return {
-        type,
-        operator: expression.operator,
-        left: transform(expression.left),
-        right: transform(expression.right),
-      };
-    case 'CallExpression':
-      return {
-        type,
-        callee: expression.callee,
-        arguments: expression.arguments.map(transform),
-      };
-    case 'Identifier':
-      return expression;
-    case 'Literal':
-      return {
-        type,
-        value: from(expression.value),
-      };
-    case 'UnaryExpression':
-      return {
-        type,
-        operator: expression.operator,
-        argument: transform(expression.argument),
-      };
-    default:
-      throw unexpectedExpressionType(type);
-  }
-};
-
 const binary: Record<BinaryExpression['operator'], (left: Complex, right: Complex) => Complex> = {
   '+': add,
   '-': sub,
@@ -86,70 +52,54 @@ const unary: Record<UnaryExpression['operator'], (arg: Complex) => Complex> = {
   '-': (arg) => new Complex(0 - arg._real, 0 - arg._imag, arg._abs, 0 - arg._arg, arg._has),
 };
 
-const toString = <T>(expression: Expression<T>): string => {
-  const { type } = expression;
-
-  switch (type) {
-    case 'BinaryExpression':
-      return `(${toString(expression.left)}${expression.operator}${toString(expression.right)})`;
-    case 'CallExpression':
-      return `${toString(expression.callee)}(${expression.arguments.map(toString).join(', ')})`;
-    case 'Identifier':
-      return expression.name;
-    case 'Literal':
-      return `${expression.value}`;
-    case 'UnaryExpression':
-      return `${expression.operator}${toString(expression.argument)}`;
-    default:
-      throw unexpectedExpressionType(type);
+const asComplexOrThrow = (value: Value) => {
+  if (typeof value !== 'object') {
+    throw new TypeError(`${typeof value} is not an object`);
   }
-};
 
-const assertComplex = (value: Value, expression: Expression<Complex>) => {
-  if (typeof value === 'function') {
-    throw new TypeError(`${toString(expression)} is a function`);
-  }
   return value;
 };
 
-const assertFunction = (value: Value, expression: Expression<Complex>) => {
+const asFunctionOrThrow = (value: Value) => {
   if (typeof value !== 'function') {
-    throw new TypeError(`${toString(expression)} is not a function`);
+    throw new TypeError(`${typeof value} is not a function`);
   }
+
   return value;
 };
 
-const convert = (expression: Expression<Complex>): (variables: Bindings) => Value => {
+const hasOwnProperty = (object: unknown, propertyKey: PropertyKey) => (
+  Object.prototype.hasOwnProperty.call(object, propertyKey)
+);
+
+const generate = (expression: Expression<Complex>): (variables: Bindings) => Value => {
   const { type } = expression;
 
   switch (type) {
     case 'BinaryExpression': {
       const operator = binary[expression.operator];
-      const left = convert(expression.left);
-      const right = convert(expression.right);
+      const left = generate(expression.left);
+      const right = generate(expression.right);
       return (variables) => operator(
-        assertComplex(left(variables), expression.left),
-        assertComplex(right(variables), expression.right),
+        asComplexOrThrow(left(variables)),
+        asComplexOrThrow(right(variables)),
       );
     }
     case 'CallExpression': {
-      const callee = convert(expression.callee);
-      const args = expression.arguments.map(convert);
-      return (variables) => assertFunction(
-        callee(variables), expression.callee,
-      ).apply(
+      const callee = generate(expression.callee);
+      const args = expression.arguments.map(generate);
+      return (variables) => asFunctionOrThrow(callee(variables)).apply(
         undefined,
-        args.map((argument, index) => assertComplex(
-          argument(variables), expression.arguments[index],
-        )),
+        args.map((argument) => asComplexOrThrow(argument(variables))),
       );
     }
     case 'Identifier': {
       const { name } = expression;
       return (variables) => {
-        if (!Object.prototype.hasOwnProperty.call(variables, name)) {
+        if (!hasOwnProperty(variables, name)) {
           throw new ReferenceError(`${name} is not defined`);
         }
+
         return variables[name];
       };
     }
@@ -159,17 +109,15 @@ const convert = (expression: Expression<Complex>): (variables: Bindings) => Valu
     }
     case 'UnaryExpression': {
       const operator = unary[expression.operator];
-      const argument = convert(expression.argument);
-      return (variables) => operator(
-        assertComplex(argument(variables), expression.argument),
-      );
+      const argument = generate(expression.argument);
+      return (variables) => operator(asComplexOrThrow(argument(variables)));
     }
     default:
       throw unexpectedExpressionType(type);
   }
 };
 
-const isConstant = (expression: Expression<Complex>, constants: Bindings): boolean => {
+const isConstant = (expression: Expression<unknown>, constants: Bindings): boolean => {
   const { type } = expression;
 
   switch (type) {
@@ -179,7 +127,7 @@ const isConstant = (expression: Expression<Complex>, constants: Bindings): boole
       return isConstant(expression.callee, constants)
         && expression.arguments.every((argument) => isConstant(argument, constants));
     case 'Identifier':
-      return Object.prototype.hasOwnProperty.call(constants, expression.name);
+      return hasOwnProperty(constants, expression.name);
     case 'Literal':
       return true;
     case 'UnaryExpression':
@@ -189,43 +137,55 @@ const isConstant = (expression: Expression<Complex>, constants: Bindings): boole
   }
 };
 
-const simplify = (expression: Expression<Complex>, constants: Bindings): Expression<Complex> => {
-  const { type } = expression;
+const asLiteralIfConstant = (
+  expression: Expression<Complex>, constants: Bindings,
+): Expression<Complex> => {
+  if (!isConstant(expression, constants)) {
+    return expression;
+  }
+
+  const evaluate = generate(expression);
+  return { type: 'Literal', value: asComplexOrThrow(evaluate(constants)) };
+};
+
+const transform = (real: Expression<number>, constants: Bindings): Expression<Complex> => {
+  const { type } = real;
 
   switch (type) {
     case 'BinaryExpression':
+      return asLiteralIfConstant({
+        type,
+        operator: real.operator,
+        left: transform(real.left, constants),
+        right: transform(real.right, constants),
+      }, constants);
     case 'CallExpression':
+      return asLiteralIfConstant({
+        type,
+        callee: real.callee,
+        arguments: real.arguments.map((argument) => transform(argument, constants)),
+      }, constants);
+    case 'Identifier':
+      return real;
+    case 'Literal':
+      return {
+        type,
+        value: from(real.value),
+      };
     case 'UnaryExpression':
-      if (isConstant(expression, constants)) {
-        return { type: 'Literal', value: assertComplex(convert(expression)(constants), expression) };
-      }
-
-      if (type === 'BinaryExpression') {
-        return {
-          type,
-          operator: expression.operator,
-          left: simplify(expression.left, constants),
-          right: simplify(expression.right, constants),
-        };
-      }
-
-      if (type === 'CallExpression') {
-        return {
-          type,
-          callee: expression.callee,
-          arguments: expression.arguments.map((argument) => simplify(argument, constants)),
-        };
-      }
-
-      return expression;
+      return asLiteralIfConstant({
+        type,
+        operator: real.operator,
+        argument: transform(real.argument, constants),
+      }, constants);
     default:
-      return expression;
+      throw unexpectedExpressionType(type);
   }
 };
 
 const compile = (expression: string, constants: Bindings = {}): (variables: Bindings) => Value => {
   const record = Object.assign({}, bindings, constants);
-  const evaluate = convert(simplify(transform(parse(expression)), record));
+  const evaluate = generate(transform(parse(expression), record));
   return (variables) => evaluate(Object.assign({}, record, variables));
 };
 

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -148,35 +148,35 @@ const asLiteralIfConstant = (
   return { type: 'Literal', value: asComplexOrThrow(evaluate(constants)) };
 };
 
-const transform = (real: Expression<number>, constants: Bindings): Expression<Complex> => {
-  const { type } = real;
+const transform = (expression: Expression<number>, constants: Bindings): Expression<Complex> => {
+  const { type } = expression;
 
   switch (type) {
     case 'BinaryExpression':
       return asLiteralIfConstant({
         type,
-        operator: real.operator,
-        left: transform(real.left, constants),
-        right: transform(real.right, constants),
+        operator: expression.operator,
+        left: transform(expression.left, constants),
+        right: transform(expression.right, constants),
       }, constants);
     case 'CallExpression':
       return asLiteralIfConstant({
         type,
-        callee: real.callee,
-        arguments: real.arguments.map((argument) => transform(argument, constants)),
+        callee: expression.callee,
+        arguments: expression.arguments.map((argument) => transform(argument, constants)),
       }, constants);
     case 'Identifier':
-      return real;
+      return expression;
     case 'Literal':
       return {
         type,
-        value: from(real.value),
+        value: from(expression.value),
       };
     case 'UnaryExpression':
       return asLiteralIfConstant({
         type,
-        operator: real.operator,
-        argument: transform(real.argument, constants),
+        operator: expression.operator,
+        argument: transform(expression.argument, constants),
       }, constants);
     default:
       throw unexpectedExpressionType(type);

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -1,0 +1,232 @@
+/* eslint-disable prefer-object-spread, prefer-spread */
+import Complex from '../complex';
+import { E, I, PI } from '../constants';
+import { BinaryExpression, Expression, UnaryExpression, parse } from '../parser';
+import { acos, acosh, add, asin, asinh, atan, atanh, cbrt, conj, cos, cosh, div, exp, from, log, mod, mul, pow, proj, sin, sinh, sqrt, sub, tan, tanh, trunc } from '../static';
+
+export type Value = Complex | ((...args: Complex[]) => Complex);
+
+export type Bindings = Record<string, Value>;
+
+export const bindings: Bindings = {
+  acos,
+  acosh,
+  asin,
+  asinh,
+  atan,
+  atanh,
+  cbrt,
+  conj,
+  cos,
+  cosh,
+  e: E,
+  exp,
+  i: I,
+  log,
+  mod,
+  pi: PI,
+  pow,
+  proj,
+  sin,
+  sinh,
+  sqrt,
+  tan,
+  tanh,
+  trunc,
+};
+
+const unexpectedExpressionType = (type: never) => new TypeError(`Unexpected expression type ${type}`);
+
+const transform = (expression: Expression): Expression<Complex> => {
+  const { type } = expression;
+
+  switch (type) {
+    case 'BinaryExpression':
+      return {
+        type,
+        operator: expression.operator,
+        left: transform(expression.left),
+        right: transform(expression.right),
+      };
+    case 'CallExpression':
+      return {
+        type,
+        callee: expression.callee,
+        arguments: expression.arguments.map(transform),
+      };
+    case 'Identifier':
+      return expression;
+    case 'Literal':
+      return {
+        type,
+        value: from(expression.value),
+      };
+    case 'UnaryExpression':
+      return {
+        type,
+        operator: expression.operator,
+        argument: transform(expression.argument),
+      };
+    default:
+      throw unexpectedExpressionType(type);
+  }
+};
+
+const binary: Record<BinaryExpression['operator'], (left: Complex, right: Complex) => Complex> = {
+  '+': add,
+  '-': sub,
+  '*': mul,
+  '/': div,
+  '**': pow,
+  '%': mod,
+};
+
+const unary: Record<UnaryExpression['operator'], (arg: Complex) => Complex> = {
+  '+': (arg) => arg,
+  '-': (arg) => new Complex(0 - arg._real, 0 - arg._imag, arg._abs, 0 - arg._arg, arg._has),
+};
+
+const toString = <T>(expression: Expression<T>): string => {
+  const { type } = expression;
+
+  switch (type) {
+    case 'BinaryExpression':
+      return `(${toString(expression.left)}${expression.operator}${toString(expression.right)})`;
+    case 'CallExpression':
+      return `${toString(expression.callee)}(${expression.arguments.map(toString).join(', ')})`;
+    case 'Identifier':
+      return expression.name;
+    case 'Literal':
+      return `${expression.value}`;
+    case 'UnaryExpression':
+      return `${expression.operator}${toString(expression.argument)}`;
+    default:
+      throw unexpectedExpressionType(type);
+  }
+};
+
+const assertComplex = (value: Value, expression: Expression<Complex>) => {
+  if (typeof value === 'function') {
+    throw new TypeError(`${toString(expression)} is a function`);
+  }
+  return value;
+};
+
+const assertFunction = (value: Value, expression: Expression<Complex>) => {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${toString(expression)} is not a function`);
+  }
+  return value;
+};
+
+const convert = (expression: Expression<Complex>): (variables: Bindings) => Value => {
+  const { type } = expression;
+
+  switch (type) {
+    case 'BinaryExpression': {
+      const operator = binary[expression.operator];
+      const left = convert(expression.left);
+      const right = convert(expression.right);
+      return (variables) => operator(
+        assertComplex(left(variables), expression.left),
+        assertComplex(right(variables), expression.right),
+      );
+    }
+    case 'CallExpression': {
+      const callee = convert(expression.callee);
+      const args = expression.arguments.map(convert);
+      return (variables) => assertFunction(
+        callee(variables), expression.callee,
+      ).apply(
+        undefined,
+        args.map((argument, index) => assertComplex(
+          argument(variables), expression.arguments[index],
+        )),
+      );
+    }
+    case 'Identifier': {
+      const { name } = expression;
+      return (variables) => {
+        if (!Object.prototype.hasOwnProperty.call(variables, name)) {
+          throw new ReferenceError(`${name} is not defined`);
+        }
+        return variables[name];
+      };
+    }
+    case 'Literal': {
+      const { value } = expression;
+      return () => value;
+    }
+    case 'UnaryExpression': {
+      const operator = unary[expression.operator];
+      const argument = convert(expression.argument);
+      return (variables) => operator(
+        assertComplex(argument(variables), expression.argument),
+      );
+    }
+    default:
+      throw unexpectedExpressionType(type);
+  }
+};
+
+const isConstant = (expression: Expression<Complex>, constants: Bindings): boolean => {
+  const { type } = expression;
+
+  switch (type) {
+    case 'BinaryExpression':
+      return isConstant(expression.left, constants) && isConstant(expression.right, constants);
+    case 'CallExpression':
+      return isConstant(expression.callee, constants)
+        && expression.arguments.every((argument) => isConstant(argument, constants));
+    case 'Identifier':
+      return Object.prototype.hasOwnProperty.call(constants, expression.name);
+    case 'Literal':
+      return true;
+    case 'UnaryExpression':
+      return isConstant(expression.argument, constants);
+    default:
+      throw unexpectedExpressionType(type);
+  }
+};
+
+const simplify = (expression: Expression<Complex>, constants: Bindings): Expression<Complex> => {
+  const { type } = expression;
+
+  switch (type) {
+    case 'BinaryExpression':
+    case 'CallExpression':
+    case 'UnaryExpression':
+      if (isConstant(expression, constants)) {
+        return { type: 'Literal', value: assertComplex(convert(expression)(constants), expression) };
+      }
+
+      if (type === 'BinaryExpression') {
+        return {
+          type,
+          operator: expression.operator,
+          left: simplify(expression.left, constants),
+          right: simplify(expression.right, constants),
+        };
+      }
+
+      if (type === 'CallExpression') {
+        return {
+          type,
+          callee: expression.callee,
+          arguments: expression.arguments.map((argument) => simplify(argument, constants)),
+        };
+      }
+
+      return expression;
+    default:
+      return expression;
+  }
+};
+
+const compile = (expression: string, constants: Bindings = {}): (variables: Bindings) => Value => {
+  const record = Object.assign({}, bindings, constants);
+  const evaluate = convert(simplify(transform(parse(expression)), record));
+  return (variables) => evaluate(Object.assign({}, record, variables));
+};
+
+export default compile;

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,0 +1,1 @@
+export { Bindings, Value, bindings, default as compile } from './compile';

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,1 +1,1 @@
-export { Bindings, Value, bindings, default as compile } from './compile';
+export { Bindings, Value, bindings, default } from './compile';

--- a/src/expressions/binary.ts
+++ b/src/expressions/binary.ts
@@ -1,0 +1,8 @@
+import { Expression } from '.';
+
+export default interface BinaryExpression<T = number> {
+  type: 'BinaryExpression';
+  operator: '+' | '-' | '*' | '/' | '%' | '**';
+  left: Expression<T>;
+  right: Expression<T>;
+}

--- a/src/expressions/call.ts
+++ b/src/expressions/call.ts
@@ -1,0 +1,7 @@
+import { Expression, Identifier } from '.';
+
+export default interface CallExpression<T = number> {
+  type: 'CallExpression';
+  callee: Identifier;
+  arguments: Expression<T>[];
+}

--- a/src/expressions/expression.ts
+++ b/src/expressions/expression.ts
@@ -1,0 +1,6 @@
+import { BinaryExpression, CallExpression, Identifier, Literal, UnaryExpression } from '.';
+
+type Expression<T = number> =
+  BinaryExpression<T> | CallExpression<T> | UnaryExpression<T> | Identifier | Literal<T>;
+
+export default Expression;

--- a/src/expressions/identifier.ts
+++ b/src/expressions/identifier.ts
@@ -1,0 +1,4 @@
+export default interface Identifier {
+  type: 'Identifier';
+  name: string;
+}

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -1,0 +1,6 @@
+export { default as BinaryExpression } from './binary';
+export { default as CallExpression } from './call';
+export { default as Expression } from './expression';
+export { default as Identifier } from './identifier';
+export { default as Literal } from './literal';
+export { default as UnaryExpression } from './unary';

--- a/src/expressions/literal.ts
+++ b/src/expressions/literal.ts
@@ -1,0 +1,4 @@
+export default interface Literal<T = number> {
+  type: 'Literal';
+  value: T;
+}

--- a/src/expressions/unary.ts
+++ b/src/expressions/unary.ts
@@ -1,0 +1,7 @@
+import { Expression } from '.';
+
+export default interface UnaryExpression<T = number> {
+  type: 'UnaryExpression';
+  operator: '+' | '-';
+  argument: Expression<T>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 export { default as Complex } from './complex';
 export { E, I, LN10, LN2, LOG10E, LOG2E, PI, SQRT1_2, SQRT2 } from './constants';
+export { BinaryExpression, CallExpression, Expression, Identifier, Literal, UnaryExpression } from './expressions';
 export {
   acos, acosh, add, asin, asinh, atan, atanh, cartesian, cbrt, conj, cos, cosh, div, exp, from, log,
   mod, mul, polar, pow, proj, sin, sinh, sqrt, sub, tan, tanh, trunc,
 } from './static';
-export { BinaryExpression, CallExpression, Expression, Identifier, Literal, UnaryExpression, parse } from './parser';
+export { default as parse } from './parser';
 export { Bindings, Value, bindings, compile } from './compiler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export {
   mod, mul, polar, pow, proj, sin, sinh, sqrt, sub, tan, tanh, trunc,
 } from './static';
 export { default as parse } from './parser';
-export { Bindings, Value, bindings, compile } from './compiler';
+export { Bindings, Value, bindings, default as compile } from './compiler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export {
   mod, mul, polar, pow, proj, sin, sinh, sqrt, sub, tan, tanh, trunc,
 } from './static';
 export { BinaryExpression, CallExpression, Expression, Identifier, Literal, UnaryExpression, parse } from './parser';
+export { Bindings, Value, bindings, compile } from './compiler';

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -1,23 +1,23 @@
 @preprocessor typescript
 
 @{%
-export interface BinaryExpression {
+export interface BinaryExpression<T = number> {
   type: 'BinaryExpression';
   operator: '+' | '-' | '*' | '/' | '%' | '**';
-  left: Expression;
-  right: Expression;
+  left: Expression<T>;
+  right: Expression<T>;
 }
 
-export interface UnaryExpression {
+export interface UnaryExpression<T = number> {
   type: 'UnaryExpression';
   operator: '+' | '-';
-  argument: Expression;
+  argument: Expression<T>;
 }
 
-export interface CallExpression {
+export interface CallExpression<T = number> {
   type: 'CallExpression';
   callee: Identifier;
-  arguments: Expression[];
+  arguments: Expression<T>[];
 }
 
 export interface Identifier {
@@ -25,12 +25,12 @@ export interface Identifier {
   name: string;
 }
 
-export interface Literal {
+export interface Literal<T = number> {
   type: 'Literal';
-  value: number;
+  value: T;
 }
 
-export type Expression = BinaryExpression | UnaryExpression | CallExpression | Identifier | Literal;
+export type Expression<T = number> = BinaryExpression<T> | UnaryExpression<T> | CallExpression<T> | Identifier | Literal<T>;
 
 const unwrap = (d: any[]) => d[1];
 const binary = (d: any[]) => ({ type: 'BinaryExpression', operator: d[2], left: d[0], right: d[4] });

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -1,37 +1,6 @@
 @preprocessor typescript
 
 @{%
-export interface BinaryExpression<T = number> {
-  type: 'BinaryExpression';
-  operator: '+' | '-' | '*' | '/' | '%' | '**';
-  left: Expression<T>;
-  right: Expression<T>;
-}
-
-export interface UnaryExpression<T = number> {
-  type: 'UnaryExpression';
-  operator: '+' | '-';
-  argument: Expression<T>;
-}
-
-export interface CallExpression<T = number> {
-  type: 'CallExpression';
-  callee: Identifier;
-  arguments: Expression<T>[];
-}
-
-export interface Identifier {
-  type: 'Identifier';
-  name: string;
-}
-
-export interface Literal<T = number> {
-  type: 'Literal';
-  value: T;
-}
-
-export type Expression<T = number> = BinaryExpression<T> | UnaryExpression<T> | CallExpression<T> | Identifier | Literal<T>;
-
 const unwrap = (d: any[]) => d[1];
 const binary = (d: any[]) => ({ type: 'BinaryExpression', operator: d[2], left: d[0], right: d[4] });
 const join = (d: any[]) => d.join('');

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,2 +1,1 @@
-export { BinaryExpression, CallExpression, Expression, Identifier, Literal, UnaryExpression } from './grammar';
-export { default as parse } from './parse';
+export { default } from './parse';

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,5 +1,6 @@
 import { Grammar, Parser } from 'nearley';
-import grammar, { Expression } from './grammar';
+import { Expression } from '../expressions';
+import grammar from './grammar';
 
 let parser: Parser;
 let state: ReturnType<Parser['save']>;


### PR DESCRIPTION
Added compiler that produces JavaScript functions from parser output.

Functions accept a single object of named properties which bind the identifiers in the parsed expression.

By default, the compiler injects bindings for all exported static functions, as well as the constants `e` and `i`.

The compiler transforms constant expressions into precomputed literals before generating the function in order to avoid unnecessary computations at runtime.